### PR TITLE
closes #76 with new implemented norms and tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,4 +28,4 @@ Suggests:
     waldo
 Config/testthat/edition: 3
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -13,17 +13,17 @@ angle_between <- function(a, b, origin = vector3(0, 0, 0)) {
   # angle between is dot divided by length.
   a <- a - origin
   b <- b - origin
-  acos(dot(a, b) / (magnitude(a) * magnitude(b)))
+  acos(dot(a, b) / (magnitude(a, "L2") * magnitude(b, "L2")))
 }
 
-#' Cacluate distance between vectors
+#' Calculate distance between vectors
 #'
 #' Measure the distance between two points `from` and `to`
 #'
 #' @param from,to Endpoints of the distance to be calculated
 #' @export
-distance_between <- function(from, to) {
-  magnitude(from - to)
+distance_between <- function(from, to, norm) {
+  magnitude(from - to, norm)
 }
 
 #' Vector projection and rejection

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -21,6 +21,8 @@ angle_between <- function(a, b, origin = vector3(0, 0, 0)) {
 #' Measure the distance between two points `from` and `to`
 #'
 #' @param from,to Endpoints of the distance to be calculated
+#' @param norm optional norm argument from list 'euclidean', 'manhattan', 'L1', 'L2', 'infinity'
+#'
 #' @export
 distance_between <- function(from, to, norm) {
   magnitude(from - to, norm)

--- a/R/vector3-operations.R
+++ b/R/vector3-operations.R
@@ -185,9 +185,34 @@ NULL
 
 #' @rdname vector3_prop
 #' @export
-magnitude <- function(v) {
-  # TODO: make that type-safety call here.
-  sqrt(v$x^2 + v$y^2 + v$z^2)
+magnitude <- function(v, norm = c("euclidean", "manhattan", "L1", "L2", "infinity")) {
+  if (!inherits(v, "dddr_vector3")) {
+    rlang::abort(
+      message = paste0(
+        "`magnitude` expects first argument to inherit from `dddr_vector3`. ",
+        "Instead, the first argument was `",
+        paste0(class(v), collapse = "/"),
+        "`."
+      ),
+      class = "dddr_error_math"
+    )
+  }
+  
+  if (missing(norm)) {
+    sqrt(v$x^2 + v$y^2 + v$z^2)
+  } 
+  else {
+    norm <- match.arg(norm)
+    
+    switch(
+      norm,
+      "euclidean" = sqrt(v$x^2 + v$y^2 + v$z^2),
+      "manhattan" = abs(v$x) + abs(v$y) + abs(v$z),
+      "L1" = abs(v$x) + abs(v$y) + abs(v$z),
+      "L2" = sqrt(v$x^2 + v$y^2 + v$z^2),
+      "infinity" = pmax(abs(v$x), abs(v$y), abs(v$z)),
+    )
+  }
 }
 
 #' @rdname vector3_prop

--- a/R/vector3-operations.R
+++ b/R/vector3-operations.R
@@ -179,6 +179,7 @@ vec_math.dddr_vector3 <- function(.fn, .x, ...) {
 #' accessible through the `magnitude` and `direction` functions.
 #'
 #' @param v vectors
+#' @param norm optional norm argument from list 'euclidean', 'manhattan', 'L1', 'L2', 'infinity'
 #'
 #' @name vector3_prop
 NULL
@@ -197,13 +198,13 @@ magnitude <- function(v, norm = c("euclidean", "manhattan", "L1", "L2", "infinit
       class = "dddr_error_math"
     )
   }
-  
+
   if (missing(norm)) {
     sqrt(v$x^2 + v$y^2 + v$z^2)
-  } 
+  }
   else {
     norm <- match.arg(norm)
-    
+
     switch(
       norm,
       "euclidean" = sqrt(v$x^2 + v$y^2 + v$z^2),

--- a/man/distance_between.Rd
+++ b/man/distance_between.Rd
@@ -2,12 +2,14 @@
 % Please edit documentation in R/spatial.R
 \name{distance_between}
 \alias{distance_between}
-\title{Cacluate distance between vectors}
+\title{Calculate distance between vectors}
 \usage{
-distance_between(from, to)
+distance_between(from, to, norm)
 }
 \arguments{
 \item{from, to}{Endpoints of the distance to be calculated}
+
+\item{norm}{optional norm argument from list 'euclidean', 'manhattan', 'L1', 'L2', 'infinity'}
 }
 \description{
 Measure the distance between two points `from` and `to`

--- a/man/geom_bin2d3.Rd
+++ b/man/geom_bin2d3.Rd
@@ -70,7 +70,7 @@ will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{geom}{Use to override the default connection between
-\code{geom_bin2d} and \code{stat_bin2d}.}
+\code{geom_bin_2d()} and \code{stat_bin_2d()}.}
 
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
@@ -103,7 +103,7 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{stat}{Use to override the default connection between
-\code{geom_bin2d} and \code{stat_bin2d}.}
+\code{geom_bin_2d()} and \code{stat_bin_2d()}.}
 }
 \description{
 To bin data points according to a view, the points need to be converted from

--- a/man/vector3_prop.Rd
+++ b/man/vector3_prop.Rd
@@ -6,12 +6,14 @@
 \alias{direction}
 \title{Vector properties}
 \usage{
-magnitude(v)
+magnitude(v, norm = c("euclidean", "manhattan", "L1", "L2", "infinity"))
 
 direction(v)
 }
 \arguments{
 \item{v}{vectors}
+
+\item{norm}{optional norm argument from list 'euclidean', 'manhattan', 'L1', 'L2', 'infinity'}
 }
 \description{
 Vectors have properties such as magnitude and direction. These are easily

--- a/tests/testthat/test-vector3.R
+++ b/tests/testthat/test-vector3.R
@@ -144,7 +144,7 @@ test_that("Vector3 magnitudes are correctly computed", {
   expect_equal(magnitude(distances), c(1, 1, 1, 5))
 })
 
-test_that("Vector3 distances are correctly computed", {
+test_that("Vector3 distances are correctly computed with no inputted norm", {
   froms <- vector3(
     x = c(1, -4, 4, 3),
     y = c(0, -3, 5, 4),
@@ -155,6 +155,81 @@ test_that("Vector3 distances are correctly computed", {
     distance_between(froms, to = vector3(0, 2, -3)),
     c(sqrt(6), sqrt(105), sqrt(41), sqrt(22))
   )
+})
+
+test_that("Vector3 distances are correctly computed with euclidean norm", {
+  froms <- vector3(
+    x = c(1, -4, 4, 3),
+    y = c(0, -3, 5, 4),
+    z = c(-2, 5, -7, 0)
+  )
+  
+  expect_equal(
+    distance_between(froms, to = vector3(0, 2, -3), "euclidean"),
+    c(sqrt(6), sqrt(105), sqrt(41), sqrt(22))
+  )
+})
+
+test_that("Vector3 distances are correctly computed with manhattan norm", {
+  froms <- vector3(
+    x = c(1, -4, 4, 3),
+    y = c(0, -3, 5, 4),
+    z = c(-2, 5, -7, 0)
+  )
+  
+  expect_equal(
+    distance_between(froms, to = vector3(0, 2, -3), "manhattan"),
+    c(4, 17, 11, 8)
+  )
+})
+
+test_that("Vector3 distances are correctly computed with L1 norm", {
+  froms <- vector3(
+    x = c(1, -4, 4, 3),
+    y = c(0, -3, 5, 4),
+    z = c(-2, 5, -7, 0)
+  )
+  
+  expect_equal(
+    distance_between(froms, to = vector3(0, 2, -3), "L1"),
+    c(4, 17, 11, 8)
+  )
+})
+
+test_that("Vector3 distances are correctly computed with L2 norm", {
+  froms <- vector3(
+    x = c(1, -4, 4, 3),
+    y = c(0, -3, 5, 4),
+    z = c(-2, 5, -7, 0)
+  )
+  
+  expect_equal(
+    distance_between(froms, to = vector3(0, 2, -3), "L2"),
+    c(sqrt(6), sqrt(105), sqrt(41), sqrt(22))
+  )
+})
+
+test_that("Vector3 distances are correctly computed with infinity norm", {
+  froms <- vector3(
+    x = c(1, -4, 4, 3),
+    y = c(0, -3, 5, 4),
+    z = c(-2, 5, -7, 0)
+  )
+  
+  expect_equal(
+    distance_between(froms, to = vector3(0, 2, -3), "infinity"),
+    c(2, 8, 4, 3)
+  )
+})
+
+test_that("Vector3 distances throws an error with unknown norm", {
+  froms <- vector3(
+    x = c(1, -4, 4, 3),
+    y = c(0, -3, 5, 4),
+    z = c(-2, 5, -7, 0)
+  )
+  
+  expect_error(distance_between(froms, to = vector3(0, 2, -3), "unknown"))
 })
 
 test_that("Vector3 can be normalized", {

--- a/tests/testthat/test-vector3.R
+++ b/tests/testthat/test-vector3.R
@@ -144,7 +144,7 @@ test_that("Vector3 magnitudes are correctly computed", {
   expect_equal(magnitude(distances), c(1, 1, 1, 5))
 })
 
-test_that("Vector3 distances are correctly computed with no inputted norm", {
+test_that("Vector3 distances are correctly computed, including with inputted norms", {
   froms <- vector3(
     x = c(1, -4, 4, 3),
     y = c(0, -3, 5, 4),
@@ -155,80 +155,26 @@ test_that("Vector3 distances are correctly computed with no inputted norm", {
     distance_between(froms, to = vector3(0, 2, -3)),
     c(sqrt(6), sqrt(105), sqrt(41), sqrt(22))
   )
-})
-
-test_that("Vector3 distances are correctly computed with euclidean norm", {
-  froms <- vector3(
-    x = c(1, -4, 4, 3),
-    y = c(0, -3, 5, 4),
-    z = c(-2, 5, -7, 0)
-  )
-  
   expect_equal(
     distance_between(froms, to = vector3(0, 2, -3), "euclidean"),
     c(sqrt(6), sqrt(105), sqrt(41), sqrt(22))
   )
-})
-
-test_that("Vector3 distances are correctly computed with manhattan norm", {
-  froms <- vector3(
-    x = c(1, -4, 4, 3),
-    y = c(0, -3, 5, 4),
-    z = c(-2, 5, -7, 0)
-  )
-  
   expect_equal(
     distance_between(froms, to = vector3(0, 2, -3), "manhattan"),
     c(4, 17, 11, 8)
   )
-})
-
-test_that("Vector3 distances are correctly computed with L1 norm", {
-  froms <- vector3(
-    x = c(1, -4, 4, 3),
-    y = c(0, -3, 5, 4),
-    z = c(-2, 5, -7, 0)
-  )
-  
   expect_equal(
     distance_between(froms, to = vector3(0, 2, -3), "L1"),
     c(4, 17, 11, 8)
   )
-})
-
-test_that("Vector3 distances are correctly computed with L2 norm", {
-  froms <- vector3(
-    x = c(1, -4, 4, 3),
-    y = c(0, -3, 5, 4),
-    z = c(-2, 5, -7, 0)
-  )
-  
   expect_equal(
     distance_between(froms, to = vector3(0, 2, -3), "L2"),
     c(sqrt(6), sqrt(105), sqrt(41), sqrt(22))
   )
-})
-
-test_that("Vector3 distances are correctly computed with infinity norm", {
-  froms <- vector3(
-    x = c(1, -4, 4, 3),
-    y = c(0, -3, 5, 4),
-    z = c(-2, 5, -7, 0)
-  )
-  
   expect_equal(
     distance_between(froms, to = vector3(0, 2, -3), "infinity"),
     c(2, 8, 4, 3)
   )
-})
-
-test_that("Vector3 distances throws an error with unknown norm", {
-  froms <- vector3(
-    x = c(1, -4, 4, 3),
-    y = c(0, -3, 5, 4),
-    z = c(-2, 5, -7, 0)
-  )
-  
   expect_error(distance_between(froms, to = vector3(0, 2, -3), "unknown"))
 })
 


### PR DESCRIPTION
- defaults to L2/Euclidean norm when no norm value is inputted
- match.arg helps with throwing an error when value is not what is expected
- added typechecking to the vector input

- 8 errors before, 8 errors after changes
- added in new tests for each norm and throws an error as expected for unknown norm value