### PR TITLE
closes #119 with an updated expected unit argument for clarity between radians and degrees

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,4 +28,4 @@ Suggests:
     waldo
 Config/testthat/edition: 3
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports:
-    dplyr (>= 1.0.0),
     ggplot2,
     pillar,
     rlang,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
 Suggests:
     covr,
     crayon,
+    dplyr,
     glue,
     knitr,
     rmarkdown,

--- a/R/tait-bryan.R
+++ b/R/tait-bryan.R
@@ -9,6 +9,7 @@ tait_bryan <- function(yaw, pitch, roll, unit = c("radians", 'degrees')) {
   if (missing(unit)) {
     stop("Expected units argument to be either 'radians' or 'degrees'")
   }
+  unit <- match.arg(unit)
 
   if (unit == "degrees") {
     yaw <- yaw / 180 * pi

--- a/R/tait-bryan.R
+++ b/R/tait-bryan.R
@@ -5,11 +5,10 @@
 #' @param yaw,pitch,roll angles
 #' @param unit Units of the angles, valid values are `"radians"` and `"degrees"`
 #' @export
-tait_bryan <- function(yaw, pitch, roll, unit = c("radians", 'degrees')) {
-  if (missing(unit)) {
-    stop("Expected units argument to be either 'radians' or 'degrees'")
+tait_bryan <- function(yaw, pitch, roll, unit) {
+  if (missing(unit) || !unit %in% c("radians", 'degrees')) {
+    stop("Expected `unit` argument to be either 'radians' or 'degrees'")
   }
-  unit <- match.arg(unit)
 
   if (unit == "degrees") {
     yaw <- yaw / 180 * pi

--- a/R/tait-bryan.R
+++ b/R/tait-bryan.R
@@ -2,16 +2,19 @@
 #'
 #' aka euler angles
 #'
-#' @param yaw,pitch,roll Angles specified in radians
-#'
+#' @param yaw,pitch,roll angles
+#' @param unit Units of the angles, valid values are `"radians"` and `"degrees"`
 #' @export
-tait_bryan <- function(yaw, pitch, roll) {
-  # throw error if angles are clearly in degrees
-  if (yaw > 2*pi || pitch > 2*pi || roll > 2*pi || yaw < -2*pi || pitch < -2*pi
-      || roll < -2*pi) {
-    stop("Expected angles 'yaw', 'pitch', and 'roll' to be specified in radians")
+tait_bryan <- function(yaw, pitch, roll, unit = c("radians", 'degrees')) {
+  if (missing(unit)) {
+    stop("Expected units argument to be either 'radians' or 'degrees'")
   }
 
+  if (unit == "degrees") {
+    yaw <- yaw / 180 * pi
+    pitch <- pitch / 180 * pi
+    roll <- roll / 180 * pi
+  }
 
   # cast to double and set length equivalent.
   l <- vctrs::vec_cast_common(yaw, pitch, roll, .to = double())

--- a/R/tait-bryan.R
+++ b/R/tait-bryan.R
@@ -6,6 +6,12 @@
 #'
 #' @export
 tait_bryan <- function(yaw, pitch, roll) {
+  # throw error if angles are clearly in degrees
+  if (yaw > 2*pi || pitch > 2*pi || roll > 2*pi || yaw < -2*pi || pitch < -2*pi
+      || roll < -2*pi) {
+    stop("Expected angles 'yaw', 'pitch', and 'roll' to be specified in radians")
+  }
+
 
   # cast to double and set length equivalent.
   l <- vctrs::vec_cast_common(yaw, pitch, roll, .to = double())

--- a/man/tait_bryan.Rd
+++ b/man/tait_bryan.Rd
@@ -4,7 +4,7 @@
 \alias{tait_bryan}
 \title{Tait-Bryan angles}
 \usage{
-tait_bryan(yaw, pitch, roll, unit = c("radians", "degrees"))
+tait_bryan(yaw, pitch, roll, unit)
 }
 \arguments{
 \item{yaw, pitch, roll}{angles}

--- a/man/tait_bryan.Rd
+++ b/man/tait_bryan.Rd
@@ -4,10 +4,12 @@
 \alias{tait_bryan}
 \title{Tait-Bryan angles}
 \usage{
-tait_bryan(yaw, pitch, roll)
+tait_bryan(yaw, pitch, roll, unit = c("radians", "degrees"))
 }
 \arguments{
-\item{yaw, pitch, roll}{Angles specified in radians}
+\item{yaw, pitch, roll}{angles}
+
+\item{unit}{Units of the angles, valid values are `"radians"` and `"degrees"`}
 }
 \description{
 aka euler angles

--- a/tests/testthat/test-tait-bryan.R
+++ b/tests/testthat/test-tait-bryan.R
@@ -1,3 +1,7 @@
+test_that("unspecified unit argument throws error", {
+  expect_error(tait_bryan(yaw = 0, pitch = 0, roll - 0))
+})
+
 test_that("null rotations have no effect.", {
 
   set_dddr_semantics(
@@ -5,7 +9,11 @@ test_that("null rotations have no effect.", {
     angles = semantics_angles(intrinsic = "ypr", hand = "left")
   )
   expect_equal(
-    tait_bryan(yaw = 0, pitch = 0, roll = 0),
+    tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="radians"),
+    quat(1, 0, 0, 0)
+  )
+  expect_equal(
+    tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="degrees"),
     quat(1, 0, 0, 0)
   )
 
@@ -14,7 +22,13 @@ test_that("null rotations have no effect.", {
     angles = semantics_angles(extrinsic = "pyr", hand = "right")
   )
   expect_equal(
-    tait_bryan(yaw = rep(0, 3), pitch = rep(0, 3), roll = rep(0, 3)),
+    tait_bryan(yaw = rep(0, 3), pitch = rep(0, 3), roll = rep(0, 3),
+               unit="radians"),
+    rep(quat(1, 0, 0, 0), 3)
+  )
+  expect_equal(
+    tait_bryan(yaw = rep(0, 3), pitch = rep(0, 3), roll = rep(0, 3),
+               unit="degrees"),
     rep(quat(1, 0, 0, 0), 3)
   )
 })
@@ -28,7 +42,11 @@ test_that("single nonzero values perform sensible rotations", {
     angles = semantics_angles(intrinsic = "ypr", hand = "left")
   )
   expect_equal(
-    tait_bryan(yaw = 0, pitch = pi / 3, roll = 0),
+    tait_bryan(yaw = 0, pitch = pi / 3, roll = 0, unit="radians"),
+    quat(cos(pi / 6), sin(pi / 6), 0, 0)
+  )
+  expect_equal(
+    tait_bryan(yaw = 0, pitch = 60, roll = 0, unit="degrees"),
     quat(cos(pi / 6), sin(pi / 6), 0, 0)
   )
 
@@ -41,7 +59,21 @@ test_that("single nonzero values perform sensible rotations", {
     tait_bryan(
       yaw = c(pi / 3, 0, 0),
       pitch = c(0, 2 * pi / 3, 0),
-      roll = c(0, 0, -pi / 3)
+      roll = c(0, 0, -pi / 3),
+      unit="radians"
+    ),
+    c(
+      quat(cos(pi / 6), 0, -sin(pi / 6), 0),
+      quat(cos(pi / 3), -sin(pi / 3), 0, 0),
+      quat(cos(pi / 6), 0, 0, sin(pi / 6))
+    )
+  )
+  expect_equal(
+    tait_bryan(
+      yaw = c(60, 0, 0),
+      pitch = c(0, 120, 0),
+      roll = c(0, 0, -60),
+      unit="degrees"
     ),
     c(
       quat(cos(pi / 6), 0, -sin(pi / 6), 0),
@@ -59,7 +91,14 @@ test_that("multiple nonzero values follow process order", {
   expect_equal(
     rotate(
       vector3(0, 0, 1),
-      tait_bryan(yaw = pi / 4, pitch = pi / 4, roll = 0)
+      tait_bryan(yaw = pi / 4, pitch = pi / 4, roll = 0, unit="radians")
+    ),
+    vector3(0.5, -sin(pi / 4), 0.5) # this says it's negative.
+  )
+  expect_equal(
+    rotate(
+      vector3(0, 0, 1),
+      tait_bryan(yaw = 45, pitch = 45, roll = 0, unit="degrees")
     ),
     vector3(0.5, -sin(pi / 4), 0.5) # this says it's negative.
   )
@@ -72,7 +111,14 @@ test_that("multiple nonzero values follow process order", {
   expect_equal(
     rotate(
       vector3(1, 0, 0),
-      tait_bryan(yaw = pi / 6, pitch = 0, roll = -pi / 6)
+      tait_bryan(yaw = pi / 6, pitch = 0, roll = -pi / 6, unit="radians")
+    ),
+    vector3(cos(pi / 6), -sin(pi / 6)^2, cos(pi / 6) * sin(pi / 6))
+  )
+  expect_equal(
+    rotate(
+      vector3(1, 0, 0),
+      tait_bryan(yaw = 30, pitch = 0, roll = -30, unit="degrees")
     ),
     vector3(cos(pi / 6), -sin(pi / 6)^2, cos(pi / 6) * sin(pi / 6))
   )
@@ -138,7 +184,8 @@ test_that("ypr goes back and forth with the right conventions", {
           pitch = pitch_angles,
           roll = roll_angles
         )
-        tb <- tait_bryan(yaw = ypr$yaw, pitch = ypr$pitch, roll = ypr$roll)
+        tb <- tait_bryan(yaw = ypr$yaw, pitch = ypr$pitch, roll = ypr$roll,
+                         unit="radians")
 
         expect_equal(f1(yaw(tb), !!angs, !!ax, !!h), ypr$yaw)
         expect_equal(f1(pitch(tb), !!angs, !!ax, !!h), ypr$pitch)
@@ -147,15 +194,6 @@ test_that("ypr goes back and forth with the right conventions", {
     }
   }
 
-})
-
-test_that("throws error if angles are specified in degrees.", {
-
-  set_dddr_semantics(
-    axes = semantics_axes_unity,
-    angles = semantics_angles(intrinsic = "ypr", hand = "left")
-  )
-  expect_error(tait_bryan(280, 300, 320))
 })
 
 set_dddr_semantics(axes = NULL, angles = NULL)

--- a/tests/testthat/test-tait-bryan.R
+++ b/tests/testthat/test-tait-bryan.R
@@ -1,6 +1,16 @@
-test_that("unspecified unit argument throws error", {
-  expect_error(tait_bryan(yaw = 0, pitch = 0, roll - 0))
+test_that("missing unit argument throws error", {
+  expect_error(tait_bryan(yaw = 0, pitch = 0, roll = 0))
 })
+
+test_that("unexpected unit argument throws error", {
+  # match.arg should not throw error for degree
+  expect_equal(
+    tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="degree"),
+    quat(1, 0, 0, 0)
+  )
+  expect_error(tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="aef"))
+})
+
 
 test_that("null rotations have no effect.", {
 

--- a/tests/testthat/test-tait-bryan.R
+++ b/tests/testthat/test-tait-bryan.R
@@ -1,14 +1,14 @@
 test_that("missing unit argument throws error", {
-  expect_error(tait_bryan(yaw = 0, pitch = 0, roll = 0))
+  expect_error(tait_bryan(yaw = 0, pitch = 0, roll = 0), "Expected `unit` argument")
 })
 
 test_that("unexpected unit argument throws error", {
-  # match.arg should not throw error for degree
-  expect_equal(
-    tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="degree"),
-    quat(1, 0, 0, 0)
+  set_dddr_semantics(
+    axes = semantics_axes_unity,
+    angles = semantics_angles(intrinsic = "ypr", hand = "left")
   )
-  expect_error(tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="aef"))
+
+  expect_error(tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="aef"), "Expected `unit` argument")
 })
 
 
@@ -22,10 +22,6 @@ test_that("null rotations have no effect.", {
     tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="radians"),
     quat(1, 0, 0, 0)
   )
-  expect_equal(
-    tait_bryan(yaw = 0, pitch = 0, roll = 0, unit="degrees"),
-    quat(1, 0, 0, 0)
-  )
 
   set_dddr_semantics(
     axes = semantics_axes_unity,
@@ -34,11 +30,6 @@ test_that("null rotations have no effect.", {
   expect_equal(
     tait_bryan(yaw = rep(0, 3), pitch = rep(0, 3), roll = rep(0, 3),
                unit="radians"),
-    rep(quat(1, 0, 0, 0), 3)
-  )
-  expect_equal(
-    tait_bryan(yaw = rep(0, 3), pitch = rep(0, 3), roll = rep(0, 3),
-               unit="degrees"),
     rep(quat(1, 0, 0, 0), 3)
   )
 })
@@ -53,10 +44,6 @@ test_that("single nonzero values perform sensible rotations", {
   )
   expect_equal(
     tait_bryan(yaw = 0, pitch = pi / 3, roll = 0, unit="radians"),
-    quat(cos(pi / 6), sin(pi / 6), 0, 0)
-  )
-  expect_equal(
-    tait_bryan(yaw = 0, pitch = 60, roll = 0, unit="degrees"),
     quat(cos(pi / 6), sin(pi / 6), 0, 0)
   )
 
@@ -78,6 +65,9 @@ test_that("single nonzero values perform sensible rotations", {
       quat(cos(pi / 6), 0, 0, sin(pi / 6))
     )
   )
+})
+
+test_that("degree rotations are computed properly", {
   expect_equal(
     tait_bryan(
       yaw = c(60, 0, 0),
@@ -105,13 +95,6 @@ test_that("multiple nonzero values follow process order", {
     ),
     vector3(0.5, -sin(pi / 4), 0.5) # this says it's negative.
   )
-  expect_equal(
-    rotate(
-      vector3(0, 0, 1),
-      tait_bryan(yaw = 45, pitch = 45, roll = 0, unit="degrees")
-    ),
-    vector3(0.5, -sin(pi / 4), 0.5) # this says it's negative.
-  )
 
   set_dddr_semantics(
     axes = semantics_axes(x = "forward", y = "up", hand = "left"),
@@ -122,13 +105,6 @@ test_that("multiple nonzero values follow process order", {
     rotate(
       vector3(1, 0, 0),
       tait_bryan(yaw = pi / 6, pitch = 0, roll = -pi / 6, unit="radians")
-    ),
-    vector3(cos(pi / 6), -sin(pi / 6)^2, cos(pi / 6) * sin(pi / 6))
-  )
-  expect_equal(
-    rotate(
-      vector3(1, 0, 0),
-      tait_bryan(yaw = 30, pitch = 0, roll = -30, unit="degrees")
     ),
     vector3(cos(pi / 6), -sin(pi / 6)^2, cos(pi / 6) * sin(pi / 6))
   )

--- a/tests/testthat/test-tait-bryan.R
+++ b/tests/testthat/test-tait-bryan.R
@@ -20,7 +20,7 @@ test_that("null rotations have no effect.", {
 })
 
 
-# test single nonzero valyes, those are easiest to think about
+# test single nonzero values, those are easiest to think about
 
 test_that("single nonzero values perform sensible rotations", {
   set_dddr_semantics(
@@ -147,6 +147,15 @@ test_that("ypr goes back and forth with the right conventions", {
     }
   }
 
+})
+
+test_that("throws error if angles are specified in degrees.", {
+
+  set_dddr_semantics(
+    axes = semantics_axes_unity,
+    angles = semantics_angles(intrinsic = "ypr", hand = "left")
+  )
+  expect_error(tait_bryan(280, 300, 320))
 })
 
 set_dddr_semantics(axes = NULL, angles = NULL)


### PR DESCRIPTION
Preference for using `unit = c("radians", "degrees")` instead of defaulting to `unit="radians"` for further added clarity - if the user is not aware of the unit argument they can pass in angles in degrees with no unit tag that will fail to calculate to their expectations.

Updated tests to calculate in degrees as well, to make sure the calculation of degrees to radians is as expected.

